### PR TITLE
Disable SSL on Knex connection via DB_SSL env var

### DIFF
--- a/src/db/knex.ts
+++ b/src/db/knex.ts
@@ -43,7 +43,7 @@ DB_PASSWORD=(or DB_PASS or POSTGRES_PASSWORD)
       user,
       password,
       multipleStatements: true,
-      ssl: { rejectUnauthorized: false },
+      ssl: env.DB_SSL === 'false' ? false : { rejectUnauthorized: false },
     },
     pool: {
       min: 2,


### PR DESCRIPTION
thanks for the great project!

while connecting to my local postgres instance, i had an error in `pg` regarding SSL:

```
/{...}/node_modules/pg/lib/connection.js:76
          return self.emit('error', new Error('The server does not support SSL connections'))
                                    ^

Error: The server does not support SSL connections
    at Socket.<anonymous> (/{...}/node_modules/pg/lib/connection.js:76:37)
    at Object.onceWrapper (node:events:633:26)
    at Socket.emit (node:events:518:28)
    at addChunk (node:internal/streams/readable:561:12)
    at readableAddChunkPushByteMode (node:internal/streams/readable:512:3)
    at Readable.push (node:internal/streams/readable:392:5)
    at TCP.onStreamRead (node:internal/stream_base_commons:191:23)

Node.js v20.18.1
```

I dug into the `node_modules` folder, found the knex connection, and setting the entire property to `false` made this run just fine.

Being able to set `DB_SSL=false`, and having the knex property be false, would hopefully permit this to be baked into the project rather than a manual edit I make to my node_modules :)